### PR TITLE
Update reporting of Unobserved error from crash to error

### DIFF
--- a/NuGet/Answers.nuspec
+++ b/NuGet/Answers.nuspec
@@ -18,21 +18,21 @@
   </metadata>
   <files>
     <!-- PCL -->
-    <file src="Sources/AnswersKit/bin/Release/AnswersKit.dll"
+    <file src="../Sources/AnswersKit/bin/Release/AnswersKit.dll"
           target="lib/portable-net45+win8+wpa81+wp8/AnswersKit.dll" />
-    <file src="Sources/AnswersKit.Pcl/bin/Release/AnswersKit.Platform.dll"
+    <file src="../Sources/AnswersKit.Pcl/bin/Release/AnswersKit.Platform.dll"
           target="lib/portable-net45+win8+wpa81+wp8/AnswersKit.Platform.dll" />
 
     <!-- Xamarin.Android -->
-    <file src="Sources/AnswersKit/bin/Release/AnswersKit.dll"
+    <file src="../Sources/AnswersKit/bin/Release/AnswersKit.dll"
           target="lib/MonoAndroid10/AnswersKit.dll" />
-    <file src="Sources/AnswersKit.Droid/bin/Release/AnswersKit.Platform.dll"
+    <file src="../Sources/AnswersKit.Droid/bin/Release/AnswersKit.Platform.dll"
           target="lib/MonoAndroid10/AnswersKit.Platform.dll" />
 
     <!-- Xamarin.iOS -->
-    <file src="Sources/AnswersKit/bin/Release/AnswersKit.dll"
+    <file src="../Sources/AnswersKit/bin/Release/AnswersKit.dll"
           target="lib/Xamarin.iOS10/AnswersKit.dll" />
-    <file src="Sources/AnswersKit.Touch/bin/Release/AnswersKit.Platform.dll"
+    <file src="../Sources/AnswersKit.Touch/bin/Release/AnswersKit.Platform.dll"
           target="lib/Xamarin.iOS10/AnswersKit.Platform.dll" />
   </files>
 </package>

--- a/NuGet/Crashlytics.nuspec
+++ b/NuGet/Crashlytics.nuspec
@@ -26,29 +26,29 @@
   </metadata>
   <files>
     <!-- PCL -->
-    <file src="Sources/CrashlyticsKit/bin/Release/CrashlyticsKit.dll"
+    <file src="../Sources/CrashlyticsKit/bin/Release/CrashlyticsKit.dll"
           target="lib/portable-net45+win8+wpa81+wp8/CrashlyticsKit.dll" />
-    <file src="Sources/CrashlyticsKit.Pcl/bin/Release/CrashlyticsKit.Platform.dll"
+    <file src="../Sources/CrashlyticsKit.Pcl/bin/Release/CrashlyticsKit.Platform.dll"
           target="lib/portable-net45+win8+wpa81+wp8/CrashlyticsKit.Platform.dll" />
 
     <!-- Xamarin.Android -->
-    <file src="Sources/AnswersKit/bin/Release/AnswersKit.dll"
+    <file src="../Sources/AnswersKit/bin/Release/AnswersKit.dll"
           target="lib/MonoAndroid10/AnswersKit.dll" />
-    <file src="Sources/AnswersKit.Droid/bin/Release/AnswersKit.Platform.dll"
+    <file src="../Sources/AnswersKit.Droid/bin/Release/AnswersKit.Platform.dll"
           target="lib/MonoAndroid10/AnswersKit.Platform.dll" />
-    <file src="Sources/CrashlyticsKit/bin/Release/CrashlyticsKit.dll"
+    <file src="../Sources/CrashlyticsKit/bin/Release/CrashlyticsKit.dll"
           target="lib/MonoAndroid10/CrashlyticsKit.dll" />
-    <file src="Sources/CrashlyticsKit.Droid/bin/Release/CrashlyticsKit.Platform.dll"
+    <file src="../Sources/CrashlyticsKit.Droid/bin/Release/CrashlyticsKit.Platform.dll"
           target="lib/MonoAndroid10/CrashlyticsKit.Platform.dll" />
 
     <!-- Xamarin.iOS -->
-    <file src="Sources/AnswersKit/bin/Release/AnswersKit.dll"
+    <file src="../Sources/AnswersKit/bin/Release/AnswersKit.dll"
           target="lib/Xamarin.iOS10/AnswersKit.dll" />
-    <file src="Sources/CrashlyticsKit.Answers.Touch/bin/Release/AnswersKit.Platform.dll"
+    <file src="../Sources/CrashlyticsKit.Answers.Touch/bin/Release/AnswersKit.Platform.dll"
           target="lib/Xamarin.iOS10/AnswersKit.Platform.dll" />
-    <file src="Sources/CrashlyticsKit/bin/Release/CrashlyticsKit.dll"
+    <file src="../Sources/CrashlyticsKit/bin/Release/CrashlyticsKit.dll"
           target="lib/Xamarin.iOS10/CrashlyticsKit.dll" />
-    <file src="Sources/CrashlyticsKit.Touch/bin/Release/CrashlyticsKit.Platform.dll"
+    <file src="../Sources/CrashlyticsKit.Touch/bin/Release/CrashlyticsKit.Platform.dll"
           target="lib/Xamarin.iOS10/CrashlyticsKit.Platform.dll" />
   </files>
 </package>

--- a/NuGet/Digits.nuspec
+++ b/NuGet/Digits.nuspec
@@ -25,25 +25,25 @@
   </metadata>
   <files>
     <!-- PCL -->
-    <file src="Sources/DigitsKit/bin/Release/DigitsKit.dll"
+    <file src="../Sources/DigitsKit/bin/Release/DigitsKit.dll"
           target="lib/portable-net45+win8+wpa81+wp8/DigitsKit.dll" />
-    <file src="Sources/DigitsKit.Pcl/bin/Release/DigitsKit.Platform.dll"
+    <file src="../Sources/DigitsKit.Pcl/bin/Release/DigitsKit.Platform.dll"
           target="lib/portable-net45+win8+wpa81+wp8/DigitsKit.Platform.dll" />
 
     <!-- Xamarin.Android -->
-    <file src="Sources/TwitterCore.Droid/bin/Release/TwitterCore.Platform.dll"
+    <file src="../Sources/TwitterCore.Droid/bin/Release/TwitterCore.Platform.dll"
           target="lib/MonoAndroid10/TwitterCore.Platform.dll" />
-    <file src="Sources/DigitsKit/bin/Release/DigitsKit.dll"
+    <file src="../Sources/DigitsKit/bin/Release/DigitsKit.dll"
           target="lib/MonoAndroid10/DigitsKit.dll" />
-    <file src="Sources/DigitsKit.Droid/bin/Release/DigitsKit.Platform.dll"
+    <file src="../Sources/DigitsKit.Droid/bin/Release/DigitsKit.Platform.dll"
           target="lib/MonoAndroid10/DigitsKit.Platform.dll" />
 
     <!-- Xamarin.iOS -->
-    <file src="Sources/TwitterCore.Touch/bin/Release/TwitterCore.Platform.dll"
+    <file src="../Sources/TwitterCore.Touch/bin/Release/TwitterCore.Platform.dll"
           target="lib/Xamarin.iOS10/TwitterCore.Platform.dll" />
-    <file src="Sources/DigitsKit/bin/Release/DigitsKit.dll"
+    <file src="../Sources/DigitsKit/bin/Release/DigitsKit.dll"
           target="lib/Xamarin.iOS10/DigitsKit.dll" />
-    <file src="Sources/DigitsKit.Touch/bin/Release/DigitsKit.Platform.dll"
+    <file src="../Sources/DigitsKit.Touch/bin/Release/DigitsKit.Platform.dll"
           target="lib/Xamarin.iOS10/DigitsKit.Platform.dll" />
   </files>
 </package>

--- a/NuGet/Fabric.nuspec
+++ b/NuGet/Fabric.nuspec
@@ -15,20 +15,20 @@
   </metadata>
   <files>
     <!-- PCL -->
-    <file src="Sources/FabricSdk/bin/Release/FabricSdk.dll"
+    <file src="../Sources/FabricSdk/bin/Release/FabricSdk.dll"
           target="lib/portable-net45+win8+wpa81+wp8/FabricSdk.dll" />    
-    <file src="Sources/FabricSdk.Pcl/bin/Release/FabricSdk.Platform.dll"
+    <file src="../Sources/FabricSdk.Pcl/bin/Release/FabricSdk.Platform.dll"
           target="lib/portable-net45+win8+wpa81+wp8/FabricSdk.Platform.dll" />    
     <!-- Xamarin.Android -->
-    <file src="Sources/FabricSdk/bin/Release/FabricSdk.dll"
+    <file src="../Sources/FabricSdk/bin/Release/FabricSdk.dll"
           target="lib/MonoAndroid10/FabricSdk.dll" />
-    <file src="Sources/FabricSdk.Droid/bin/Release/FabricSdk.Platform.dll"
+    <file src="../Sources/FabricSdk.Droid/bin/Release/FabricSdk.Platform.dll"
       target="lib/MonoAndroid10/FabricSdk.Platform.dll" />
     
     <!-- Xamarin.iOS -->
-    <file src="Sources/FabricSdk/bin/Release/FabricSdk.dll"
+    <file src="../Sources/FabricSdk/bin/Release/FabricSdk.dll"
           target="lib/Xamarin.iOS10/FabricSdk.dll" />
-    <file src="Sources/FabricSdk.Touch/bin/Release/FabricSdk.Platform.dll"
+    <file src="../Sources/FabricSdk.Touch/bin/Release/FabricSdk.Platform.dll"
       target="lib/Xamarin.iOS10/FabricSdk.Platform.dll" />
 
   </files>

--- a/Sources/AnswersKit.Droid/AnswersKit.Droid.csproj
+++ b/Sources/AnswersKit.Droid/AnswersKit.Droid.csproj
@@ -34,14 +34,14 @@
   <ItemGroup>
     <Reference Include="Mono.Android" />
     <Reference Include="System" />
-    <Reference Include="System.Collections">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoAndroid\v1.0\Facades\System.Collections.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoAndroid\v1.0\Facades\System.Runtime.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.Android.framework\Versions\7.4.0-21\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections">
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.Android.framework\Versions\7.4.0-21\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades\System.Collections.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Answers.cs" />

--- a/Sources/AnswersKit.Touch/AnswersKit.Touch.csproj
+++ b/Sources/AnswersKit.Touch/AnswersKit.Touch.csproj
@@ -32,13 +32,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="Xamarin.iOS" />
     <Reference Include="System.Collections">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoTouch\v1.0\Facades\System.Collections.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.iOS.framework\Versions\10.12.0.20\lib\mono\Xamarin.iOS\Facades\System.Collections.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoTouch\v1.0\Facades\System.Runtime.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.iOS.framework\Versions\10.12.0.20\lib\mono\Xamarin.iOS\Facades\System.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/Sources/CrashlyticsKit.Droid/Crashlytics.cs
+++ b/Sources/CrashlyticsKit.Droid/Crashlytics.cs
@@ -98,11 +98,11 @@ namespace CrashlyticsKit
             return this;
         }
 
-		public ICrashlytics Log(string msg)
-		{
-			Bindings.CrashlyticsKit.Crashlytics.Log(msg);
-			return this;
-		}
+        public ICrashlytics Log(string msg)
+        {
+            Bindings.CrashlyticsKit.Crashlytics.Log(msg);
+            return this;
+        }
 
 
         internal static Throwable ToThrowable(Exception exception)
@@ -152,7 +152,7 @@ namespace CrashlyticsKit
     }
 
     public static class Initializer
-    {        
+    {
         private static readonly object InitializeLock = new object();
         private static Thread.IUncaughtExceptionHandler _defaultExceptionHandler;
         private static Thread.IUncaughtExceptionHandler _uncaughtExceptionHandler;
@@ -160,22 +160,12 @@ namespace CrashlyticsKit
 
         private static void UncaughtException(object exeptionObject)
         {
-            var exception = exeptionObject as Exception;
-            if (exception == null)
-                return;
-
-            Bindings.CrashlyticsKit.Crashlytics.SetString("fatal exception stack trace", exception.StackTrace ?? string.Empty);
-            Bindings.CrashlyticsKit.Crashlytics.SetString("fatal exception message", exception.Message);
-            Bindings.CrashlyticsKit.Crashlytics.SetString("fatal exception", exception.GetType().FullName);
-
-            var throwable = Crashlytics.ToThrowable(exception);
-
-            _uncaughtExceptionHandler.UncaughtException(Thread.CurrentThread(), throwable);
-            System.Diagnostics.Process.GetCurrentProcess().Kill();
-            Environment.Exit(10);
+            if (exeptionObject is Exception exception)
+            {
+                Crashlytics.Instance.RecordException(exception);
+            }
         }
 
-        
         public static void Initialize(this ICrashlytics crashlytics)
         {
             if (_initialized) return;

--- a/Sources/CrashlyticsKit.Droid/CrashlyticsKit.Droid.csproj
+++ b/Sources/CrashlyticsKit.Droid/CrashlyticsKit.Droid.csproj
@@ -35,10 +35,10 @@
     <Reference Include="Mono.Android" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoAndroid\v1.0\Facades\System.Runtime.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.Android.framework\Versions\7.4.0-21\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades\System.Runtime.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Crashlytics.cs" />

--- a/Sources/CrashlyticsKit.Touch/Crashlytics.cs
+++ b/Sources/CrashlyticsKit.Touch/Crashlytics.cs
@@ -19,12 +19,12 @@ namespace CrashlyticsKit
         private static readonly Lazy<Crashlytics> LazyInstance = new Lazy<Crashlytics>(() => new Crashlytics());
 
         private Crashlytics() : base(Bindings.CrashlyticsKit.Crashlytics.SharedInstance)
-        {            
+        {
         }
 
         public static ICrashlytics Instance => LazyInstance.Value;
 
-        public string Version => Bindings.CrashlyticsKit.Crashlytics.SharedInstance.Version;       
+        public string Version => Bindings.CrashlyticsKit.Crashlytics.SharedInstance.Version;
 
         public void Crash()
         {
@@ -91,11 +91,11 @@ namespace CrashlyticsKit
             return this;
         }
 
-		public ICrashlytics Log(string msg)
-		{
-			CLSLog(msg);
-			return this;
-		}
+        public ICrashlytics Log(string msg)
+        {
+            CLSLog(msg);
+            return this;
+        }
 
         public void RecordException(Exception exception)
         {
@@ -132,54 +132,54 @@ namespace CrashlyticsKit
             Bindings.CrashlyticsKit.Crashlytics.SharedInstance.RecordCustomExceptionName(exception.GetType().Name, exception.Message, stackFrames.ToArray());
         }
 
-		// extern void CLSLog (NSString * format, ...);
-		[DllImport("__Internal", EntryPoint = "CLSLog")]
-		//[Verify (PlatformInvoke)]
-		internal static extern void __CLSLog(IntPtr format, string arg0);
+        // extern void CLSLog (NSString * format, ...);
+        [DllImport("__Internal", EntryPoint = "CLSLog")]
+        //[Verify (PlatformInvoke)]
+        internal static extern void __CLSLog(IntPtr format, string arg0);
 
-		// extern void CLSLog (NSString * format, ...);
-		[DllImport("__Internal", EntryPoint = "CLSLog")]
-		//[Verify (PlatformInvoke)]
-		internal static extern void __CLSLog_arm64(IntPtr format, IntPtr dummy1, IntPtr dummy2, IntPtr dummy3, IntPtr dummy4, IntPtr dummy5, IntPtr dummy6, string arg0);
+        // extern void CLSLog (NSString * format, ...);
+        [DllImport("__Internal", EntryPoint = "CLSLog")]
+        //[Verify (PlatformInvoke)]
+        internal static extern void __CLSLog_arm64(IntPtr format, IntPtr dummy1, IntPtr dummy2, IntPtr dummy3, IntPtr dummy4, IntPtr dummy5, IntPtr dummy6, string arg0);
 
-		// extern void CLSLogv (NSString * format, va_list ap);
-		[DllImport("__Internal")]
-		//[Verify (PlatformInvoke)]
-		internal static extern unsafe void CLSLogv(IntPtr format, sbyte* ap);
+        // extern void CLSLogv (NSString * format, va_list ap);
+        [DllImport("__Internal")]
+        //[Verify (PlatformInvoke)]
+        internal static extern unsafe void CLSLogv(IntPtr format, sbyte* ap);
 
-		// extern void CLSNSLog (NSString * format, ...);
-		[DllImport("__Internal", EntryPoint = "CLSNSLog")]
-		//[Verify (PlatformInvoke)]
-		internal static extern void __CLSNSLog(IntPtr format, string arg0);
+        // extern void CLSNSLog (NSString * format, ...);
+        [DllImport("__Internal", EntryPoint = "CLSNSLog")]
+        //[Verify (PlatformInvoke)]
+        internal static extern void __CLSNSLog(IntPtr format, string arg0);
 
-		// extern void CLSNSLog (NSString * format, ...);
-		[DllImport("__Internal", EntryPoint = "CLSNSLog")]
-		//[Verify (PlatformInvoke)]
-		internal static extern void __CLSNSLog_arm64(IntPtr format, IntPtr dummy1, IntPtr dummy2, IntPtr dummy3, IntPtr dummy4, IntPtr dummy5, IntPtr dummy6, string arg0);
+        // extern void CLSNSLog (NSString * format, ...);
+        [DllImport("__Internal", EntryPoint = "CLSNSLog")]
+        //[Verify (PlatformInvoke)]
+        internal static extern void __CLSNSLog_arm64(IntPtr format, IntPtr dummy1, IntPtr dummy2, IntPtr dummy3, IntPtr dummy4, IntPtr dummy5, IntPtr dummy6, string arg0);
 
-		// extern void CLSNSLogv (NSString * format, va_list ap);
-		[DllImport("__Internal")]
-		//[Verify (PlatformInvoke)]
-		internal static extern unsafe void CLSNSLogv(IntPtr format, sbyte* ap);
+        // extern void CLSNSLogv (NSString * format, va_list ap);
+        [DllImport("__Internal")]
+        //[Verify (PlatformInvoke)]
+        internal static extern unsafe void CLSNSLogv(IntPtr format, sbyte* ap);
 
-		public void CLSLog(string format, params object[] arg)
-		{
-			using (var nsFormat = new NSString(string.Format(format, arg)))
-				if (Runtime.Arch == Arch.DEVICE && IntPtr.Size == 8)
-					__CLSLog_arm64(nsFormat.Handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, "");
-				else
-					__CLSLog(nsFormat.Handle, "");
-		}
+        public void CLSLog(string format, params object[] arg)
+        {
+            using (var nsFormat = new NSString(string.Format(format, arg)))
+                if (Runtime.Arch == Arch.DEVICE && IntPtr.Size == 8)
+                    __CLSLog_arm64(nsFormat.Handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, "");
+                else
+                    __CLSLog(nsFormat.Handle, "");
+        }
 
-		public void CLSNSLog(string format, params object[] arg)
-		{
-			using (var nsFormat = new NSString(string.Format(format, arg)))
-				if (Runtime.Arch == Arch.DEVICE && IntPtr.Size == 8)
-					__CLSNSLog_arm64(nsFormat.Handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, "");
-				else
-					__CLSNSLog(nsFormat.Handle, "");
-		}
-	}
+        public void CLSNSLog(string format, params object[] arg)
+        {
+            using (var nsFormat = new NSString(string.Format(format, arg)))
+                if (Runtime.Arch == Arch.DEVICE && IntPtr.Size == 8)
+                    __CLSNSLog_arm64(nsFormat.Handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, "");
+                else
+                    __CLSNSLog(nsFormat.Handle, "");
+        }
+    }
 
     public static class Initializer
     {
@@ -188,13 +188,10 @@ namespace CrashlyticsKit
 
         public static void RecordManagedException(object exceptionObject)
         {
-            var exception = exceptionObject as Exception;
-            if (exception == null)
-                return;
-            
-            Bindings.CrashlyticsKit.Crashlytics.SharedInstance.SetObjectValue(new NSString(exception.StackTrace ?? string.Empty), "managed exception stack trace");
-            Bindings.CrashlyticsKit.Crashlytics.SharedInstance.SetObjectValue(new NSString(exception.Message), "managed exception message");
-            Bindings.CrashlyticsKit.Crashlytics.SharedInstance.SetObjectValue(new NSString(exception.GetType().FullName), "managed exception");
+            if (exceptionObject is Exception exception)
+            {
+                Bindings.CrashlyticsKit.Crashlytics.SharedInstance.RecordError(exception.ToNativeError());
+            }
         }
 
         public static void Initialize(this ICrashlytics crashlytics)
@@ -214,6 +211,13 @@ namespace CrashlyticsKit
         {
             AppDomain.CurrentDomain.UnhandledException += (s, a) => RecordManagedException(a.ExceptionObject);
             TaskScheduler.UnobservedTaskException += (s, a) => RecordManagedException(a.Exception);
+        }
+
+        static NSError ToNativeError(this Exception ex)
+        {
+            NSDictionary userInfo = NSDictionary.FromObjectsAndKeys(new object[] { ex.Message, ex.StackTrace, ex.GetType().FullName, ex.Source }, new string[] { "Message", "StackTrace", "Type", "Source" });
+
+            return NSError.FromDomain(new NSString(ex.GetType().Name), ex.HResult, userInfo);
         }
     }
 }

--- a/Sources/CrashlyticsKit.Touch/CrashlyticsKit.Touch.csproj
+++ b/Sources/CrashlyticsKit.Touch/CrashlyticsKit.Touch.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>CrashlyticsKit</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>CrashlyticsKit.Platform</AssemblyName>
+    <PackOnBuild>true</PackOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,13 +33,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoTouch\v1.0\Facades\System.Collections.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoTouch\v1.0\Facades\System.Runtime.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.iOS" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.iOS.framework\Versions\10.12.0.20\lib\mono\Xamarin.iOS\Facades\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections">
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.iOS.framework\Versions\10.12.0.20\lib\mono\Xamarin.iOS\Facades\System.Collections.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/Sources/DigitsKit.Droid/Digits.cs
+++ b/Sources/DigitsKit.Droid/Digits.cs
@@ -14,7 +14,7 @@ namespace DigitsKit
 
         public static IDigits Instance => LazyInstance.Value;
 
-		private Digits() : base(new Bindings.DigitsKit.Digits.Builder().Build())
+        private Digits() : base(new Bindings.DigitsKit.Digits.Builder().Build())
         {
         }
 
@@ -153,7 +153,7 @@ namespace DigitsKit
             if (_initialized) return;
             lock (InitializeLock)
             {
-                if (_initialized) return; 
+                if (_initialized) return;
 
                 var authConfig = new TwitterAuthConfig(consumerKey, consumerSecret);
                 var core = new TwitterCore(authConfig);
@@ -161,7 +161,7 @@ namespace DigitsKit
                 Fabric.Instance.Kits.Add(new Kit(core));
                 Fabric.Instance.Kits.Add(digits);
 
-                _initialized = true; 
+                _initialized = true;
             }
         }
     }

--- a/Sources/DigitsKit.Droid/DigitsKit.Droid.csproj
+++ b/Sources/DigitsKit.Droid/DigitsKit.Droid.csproj
@@ -40,9 +40,6 @@
     <Reference Include="Mono.Android" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoAndroid\v1.0\Facades\System.Runtime.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Square.OkIO">
       <HintPath>..\packages\Square.OkIO.1.11.0\lib\MonoAndroid\Square.OkIO.dll</HintPath>
@@ -91,6 +88,9 @@
     </Reference>
     <Reference Include="Xamarin.Android.Support.Design">
       <HintPath>..\packages\Xamarin.Android.Support.Design.25.1.1\lib\MonoAndroid70\Xamarin.Android.Support.Design.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.Android.framework\Versions\7.4.0-21\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades\System.Runtime.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Sources/DigitsKit.Touch/DigitsKit.Touch.csproj
+++ b/Sources/DigitsKit.Touch/DigitsKit.Touch.csproj
@@ -32,10 +32,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Runtime">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoTouch\v1.0\Facades\System.Runtime.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.iOS" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.iOS.framework\Versions\10.12.0.20\lib\mono\Xamarin.iOS\Facades\System.Runtime.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Digits.cs" />

--- a/Sources/FabricSdk.Droid/FabricSdk.Droid.csproj
+++ b/Sources/FabricSdk.Droid/FabricSdk.Droid.csproj
@@ -35,10 +35,10 @@
     <Reference Include="Mono.Android" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoAndroid\v1.0\Facades\System.Runtime.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.Android.framework\Versions\7.4.0-21\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades\System.Runtime.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Fabric.cs" />

--- a/Sources/FabricSdk.Touch/Fabric.cs
+++ b/Sources/FabricSdk.Touch/Fabric.cs
@@ -29,10 +29,10 @@ namespace FabricSdk
         internal void Initialize()
         {
             BeforeInitialize?.Invoke(this, new EventArgs());
-			var nativeKits = new List<NSObject>();
-			foreach (var kit in Kits)
-				nativeKits.Add(kit.ToNative());
-			Bindings.FabricSdk.Fabric.With(nativeKits.ToArray());
+            var nativeKits = new List<NSObject>();
+            foreach (var kit in Kits)
+                nativeKits.Add(kit.ToNative());
+            Bindings.FabricSdk.Fabric.With(nativeKits.ToArray());
             AfterInitialize?.Invoke(this, new EventArgs());
         }
     }

--- a/Sources/FabricSdk.Touch/FabricSdk.Touch.csproj
+++ b/Sources/FabricSdk.Touch/FabricSdk.Touch.csproj
@@ -34,6 +34,12 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Xamarin.iOS" />
+    <Reference Include="System.Collections">
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.iOS.framework\Versions\10.12.0.20\lib\mono\Xamarin.iOS\Facades\System.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Xamarin.iOS.framework\Versions\10.12.0.20\lib\mono\Xamarin.iOS\Facades\System.Runtime.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/Sources/TwitterCore.Droid/TwitterCore.Droid.csproj
+++ b/Sources/TwitterCore.Droid/TwitterCore.Droid.csproj
@@ -38,17 +38,17 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
-    <Reference Include="GoogleGson">
-      <HintPath>..\..\Samples\FormsSample\packages\GoogleGson.2.6.2.0\lib\MonoAndroid\GoogleGson.dll</HintPath>
-    </Reference>
-    <Reference Include="Square.Retrofit2">
-      <HintPath>..\..\Samples\FormsSample\packages\Square.Retrofit2.2.1.0\lib\MonoAndroid\Square.Retrofit2.dll</HintPath>
-    </Reference>
     <Reference Include="Square.OkIO">
-      <HintPath>..\..\Samples\FormsSample\packages\Square.OkIO.1.11.0\lib\MonoAndroid\Square.OkIO.dll</HintPath>
+      <HintPath>..\packages\Square.OkIO.1.6.0.0\lib\MonoAndroid\Square.OkIO.dll</HintPath>
     </Reference>
-    <Reference Include="Square.OkHttp3">
-      <HintPath>..\..\Samples\FormsSample\packages\Square.OkHttp3.3.5.0\lib\MonoAndroid\Square.OkHttp3.dll</HintPath>
+    <Reference Include="Square.OkHttp">
+      <HintPath>..\packages\Square.OkHttp.2.7.5.0\lib\MonoAndroid\Square.OkHttp.dll</HintPath>
+    </Reference>
+    <Reference Include="GoogleGson">
+      <HintPath>..\packages\GoogleGson.2.6.1.0\lib\MonoAndroid\GoogleGson.dll</HintPath>
+    </Reference>
+    <Reference Include="Square.Retrofit">
+      <HintPath>..\packages\Square.Retrofit.1.9.0.0\lib\MonoAndroid\Square.Retrofit.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Sources/TwitterCore.Droid/packages.config
+++ b/Sources/TwitterCore.Droid/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="GoogleGson" version="2.6.1.0" targetFramework="monoandroid71" />
+  <package id="Square.OkHttp" version="2.7.5.0" targetFramework="monoandroid71" />
+  <package id="Square.OkIO" version="1.6.0.0" targetFramework="monoandroid71" />
+  <package id="Square.Retrofit" version="1.9.0.0" targetFramework="monoandroid71" />
   <package id="Xamarin.Android.Bindings.Generators" version="1.6.1.19" targetFramework="monoandroid71" />
-  <package id="GoogleGson" version="2.6.2.0" targetFramework="monoandroid71" />
-  <package id="Square.OkHttp3" version="3.5.0" targetFramework="monoandroid71" />
-  <package id="Square.OkIO" version="1.11.0" targetFramework="monoandroid71" />
-  <package id="Square.Retrofit2" version="2.1.0" targetFramework="monoandroid71" />
 </packages>


### PR DESCRIPTION
* On previous implementation, all unobserved errors were reported as
crash by default, which is messing our reports. I udpated both iOS and
Android to report those error as Custom error instead, so they will
appear as non-fatal on fabrics dashboard
* Update nuspec files targetting to be able to package direclty from
NuGet folder